### PR TITLE
Remove useless comments in init.el

### DIFF
--- a/init.el
+++ b/init.el
@@ -74,7 +74,6 @@
 
 ;; Packages
 ;; Without this comment Emacs25 adds (package-initialize) here
-;; (package-initialize)
 (require 'init-package)
 
 ;; Preferences


### PR DESCRIPTION
Hello:

In fact, as long as the `(package-initialize)` exists in init.el, `package.el` will not add `(package-initialize)` into init.el anymore.
e.g.:
<img width="788" alt="1" src="https://user-images.githubusercontent.com/26828933/34699329-985a66a6-f517-11e7-8f3a-ba8fd7187e98.png">
It's enough.

Please forgive my cleanliness and obsessive-compulsive disorder……-_-b

Thanks.
  