### PR TITLE
remove excessive quote to fix python mode problem

### DIFF
--- a/lisp/init-python.el
+++ b/lisp/init-python.el
@@ -68,7 +68,7 @@
     (with-eval-after-load 'company
       (use-package company-anaconda
         :defines company-backends
-        :init (cl-pushnew '(company-backend-with-yas 'company-anaconda) company-backends)))))
+        :init (cl-pushnew (company-backend-with-yas 'company-anaconda) company-backends)))))
 
 (provide 'init-python)
 


### PR DESCRIPTION
By deleting the quote, you can close this two reported issues. #11 #15 