### PR TITLE
Integrated usable plantUML.

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -60,7 +60,11 @@
   (defvar-local load-language-list '((emacs-lisp . t)
                                      (perl . t)
                                      (python . t)
-                                     (ruby . t)))
+                                     (ruby . t)
+                                     (plantuml . t)))
+  (setq org-plantuml-jar-path
+        (expand-file-name "~/.emacs.d/plantuml.1.2018.2.jar"))
+
   (use-package ob-go
     :init
     (if (executable-find "go")


### PR DESCRIPTION
There's not a usable org-bable function of plantUML.
Now you can generate an UML with `C-c C-c` in `org-mode` like
```
#+BEGIN_SRC plantuml :file CHANGE.png
  Alice -> Bob: synchronous call
  Alice ->> Bob: asynchronous call
#+END_SRC
```
(I know it's a simple pull request but practical ;-)