### PR TITLE
Add code in init to always load new byte-compiled elisp files

### DIFF
--- a/init.el
+++ b/init.el
@@ -60,6 +60,9 @@
             (setq gc-cons-threshold 800000)
             (add-hook 'focus-out-hook 'garbage-collect)))
 
+;; Always load new byte-compiled elisp files
+(setq load-prefer-newer t)
+
 ;; Load path
 (add-to-list 'load-path (expand-file-name "lisp" user-emacs-directory))
 (add-to-list 'load-path (expand-file-name "site-lisp" user-emacs-directory))


### PR DESCRIPTION
Whenever I pull and upgrade packages, I get warning that my byte-compiled files are outdated. I added a simple setting in init file to automatically load new files. Please check if this is a good idea to include in init file, please ignore this pull request if you have other concerns. 😁