### PR TITLE
Add pyvenv to switch conda environment easily

### DIFF
--- a/init.el
+++ b/init.el
@@ -60,6 +60,9 @@
             (setq gc-cons-threshold 800000)
             (add-hook 'focus-out-hook 'garbage-collect)))
 
+;; Always load new byte-compiled elisp files
+(setq load-prefer-newer t)
+
 ;; Load path
 (add-to-list 'load-path (expand-file-name "lisp" user-emacs-directory))
 (add-to-list 'load-path (expand-file-name "site-lisp" user-emacs-directory))

--- a/lisp/init-python.el
+++ b/lisp/init-python.el
@@ -67,7 +67,16 @@
     (with-eval-after-load 'company
       (use-package company-anaconda
         :defines company-backends
-        :init (cl-pushnew (company-backend-with-yas 'company-anaconda) company-backends)))))
+        :init (cl-pushnew (company-backend-with-yas 'company-anaconda) company-backends))))
+
+  ;; Add conda environment
+  (use-package pyvenv
+    :init
+    (setenv "WORKON_HOME" "/usr/local/anaconda3/envs")
+    (pyvenv-mode 1))
+
+  )
+
 
 (provide 'init-python)
 


### PR DESCRIPTION
I think it would be a good idea to add [pyvenv](https://github.com/jorgenschaefer/pyvenv) in the **init-python.el** so python programmers can easily switch between different conda environments (by typing `M-x pyvenv-workon`).  