### PR TITLE
Implemented tab hack to ensure icon alignment

### DIFF
--- a/lisp/init-ibuffer.el
+++ b/lisp/init-ibuffer.el
@@ -42,9 +42,14 @@
   :config
   (setq ibuffer-filter-group-name-face '(:inherit (font-lock-string-face bold)))
 
+  (add-hook 'ibuffer-mode-hook
+            (lambda ()
+              (setq tab-width 1)))
+
   ;; Display buffer icons on GUI
   (when (display-graphic-p)
-    (define-ibuffer-column icon (:name " ")
+    ;; To be correctly aligned, the size of the name field must be equal to that of the icon column below, plus 1 (for the tab I inserted)
+    (define-ibuffer-column icon (:name "   ")
       (let ((icon (if (and buffer-file-name
                            (all-the-icons-match-to-alist buffer-file-name
                                                          all-the-icons-icon-alist))
@@ -56,7 +61,10 @@
           icon)))
 
     (setq ibuffer-formats '((mark modified read-only locked
-                                  " " (icon 2 2 :left :elide) (name 18 18 :left :elide)
+                                  ;; Here you may adjust by replacing :right with :center or :left
+                                  ;; According to taste, if you want the icon further from the name
+                                  " " (icon 2 2 :right :elide)
+                                  "\t" (name 18 18 :left :elide)
                                   " " (size 9 -1 :right)
                                   " " (mode 16 16 :left :elide) " " filename-and-process)
                             (mark " " (name 16 -1) " " filename))))

--- a/lisp/init-ivy.el
+++ b/lisp/init-ivy.el
@@ -338,6 +338,11 @@
   ;; For better performance
   (setq ivy-rich-parse-remote-buffer nil)
 
+  ;; Setting tab size to 1, to insert tabs as delimiters
+  (add-hook 'minibuffer-setup-hook
+	    (lambda ()
+	      (setq tab-width 1)))
+
   (setq ivy-rich-display-transformers-list
         '(ivy-switch-buffer
           (:columns
@@ -349,7 +354,8 @@
             (ivy-rich-switch-buffer-project (:width 15 :face success))
             (ivy-rich-switch-buffer-path (:width (lambda (x) (ivy-rich-switch-buffer-shorten-path x (ivy-rich-minibuffer-width 0.3))))))
            :predicate
-           (lambda (cand) (get-buffer cand)))
+           (lambda (cand) (get-buffer cand))
+	   :delimiter "\t")
           ivy-switch-buffer-other-window
           (:columns
            ((ivy-rich-buffer-icon)
@@ -360,7 +366,8 @@
             (ivy-rich-switch-buffer-project (:width 15 :face success))
             (ivy-rich-switch-buffer-path (:width (lambda (x) (ivy-rich-switch-buffer-shorten-path x (ivy-rich-minibuffer-width 0.3))))))
            :predicate
-           (lambda (cand) (get-buffer cand)))
+           (lambda (cand) (get-buffer cand))
+	   :delimiter "\t")
           counsel-switch-buffer
           (:columns
            ((ivy-rich-buffer-icon)
@@ -371,7 +378,8 @@
             (ivy-rich-switch-buffer-project (:width 15 :face success))
             (ivy-rich-switch-buffer-path (:width (lambda (x) (ivy-rich-switch-buffer-shorten-path x (ivy-rich-minibuffer-width 0.3))))))
            :predicate
-           (lambda (cand) (get-buffer cand)))
+           (lambda (cand) (get-buffer cand))
+	   :delimiter "\t")
           persp-switch-to-buffer
           (:columns
            ((ivy-rich-buffer-icon)
@@ -382,7 +390,8 @@
             (ivy-rich-switch-buffer-project (:width 15 :face success))
             (ivy-rich-switch-buffer-path (:width (lambda (x) (ivy-rich-switch-buffer-shorten-path x (ivy-rich-minibuffer-width 0.3))))))
            :predicate
-           (lambda (cand) (get-buffer cand)))
+           (lambda (cand) (get-buffer cand))
+	   :delimiter "\t")
           counsel-M-x
           (:columns
            ((counsel-M-x-transformer (:width 50))
@@ -398,28 +407,34 @@
           counsel-find-file
           (:columns
            ((ivy-rich-file-icon)
-            (ivy-read-file-transformer)))
+            (ivy-read-file-transformer))
+	   :delimiter "\t")
           counsel-file-jump
           (:columns
            ((ivy-rich-file-icon)
-            (ivy-rich-candidate)))
+            (ivy-rich-candidate))
+	   :delimiter "\t")
           counsel-dired
           (:columns
            ((ivy-rich-file-icon)
-            (ivy-read-file-transformer)))
+            (ivy-read-file-transformer))
+	   :delimiter "\t")
           counsel-dired-jump
           (:columns
            ((ivy-rich-file-icon)
-            (ivy-rich-candidate)))
+            (ivy-rich-candidate))
+	   :delimiter "\t")
           counsel-git
           (:columns
            ((ivy-rich-file-icon)
-            (ivy-rich-candidate)))
+            (ivy-rich-candidate))
+	   :delimiter "\t")
           counsel-recentf
           (:columns
            ((ivy-rich-file-icon)
             (ivy-rich-candidate (:width 0.8))
-            (ivy-rich-file-last-modified-time (:face font-lock-comment-face))))
+            (ivy-rich-file-last-modified-time (:face font-lock-comment-face)))
+	   :delimiter "\t")
           counsel-bookmark
           (:columns
            ((ivy-rich-bookmark-type)
@@ -428,19 +443,23 @@
           counsel-projectile-switch-project
           (:columns
            ((ivy-rich-file-icon)
-            (ivy-rich-candidate)))
+            (ivy-rich-candidate))
+	   :delimiter "\t")
           counsel-projectile-find-file
           (:columns
            ((ivy-rich-file-icon)
-            (counsel-projectile-find-file-transformer)))
+            (counsel-projectile-find-file-transformer))
+	   :delimiter "\t")
           counsel-projectile-find-dir
           (:columns
            ((ivy-rich-file-icon)
-            (counsel-projectile-find-dir-transformer)))
+            (counsel-projectile-find-dir-transformer))
+	   :delimiter "\t")
           treemacs-projectile
           (:columns
            ((ivy-rich-file-icon)
-            (ivy-rich-candidate))))))
+            (ivy-rich-candidate))
+	   :delimiter "\t"))))
 
 (provide 'init-ivy)
 


### PR DESCRIPTION
Related to issue #62.
I implemented my hack on the ibuffer and ivy-rich buffers.
I put comments where there is room for tweaking according to taste.

As you can see, its quite trivial, but also quite dirty. We just have to hope that changing the tab size for the ibuffer buffer and the minibuffer does not break anything in those buffers (as far as I can see, everything seems fine).