### PR TITLE
Improved ibuffer-find-file behaviour

### DIFF
--- a/lisp/init-ibuffer.el
+++ b/lisp/init-ibuffer.el
@@ -63,8 +63,17 @@
                                     " " (mode 16 16 :left :elide) " " filename-and-process)
                               (mark " " (name 16 -1) " " filename)))))
 
+  (defun my/ibuffer-find-file ()
+    (interactive)
+    (let ((default-directory (let ((buf (ibuffer-current-buffer)))
+			       (if (buffer-live-p buf)
+				   (with-current-buffer buf
+				     default-directory)
+				 default-directory))))
+      (counsel-find-file default-directory)))
+
   (with-eval-after-load 'counsel
-    (defalias #'ibuffer-find-file #'counsel-find-file))
+    (advice-add #'ibuffer-find-file :override #'my/ibuffer-find-file))
 
   ;; Group ibuffer's list by project root
   (use-package ibuffer-projectile


### PR DESCRIPTION
Hi again, Mr. Zhang !

I wrote a small improvement on your ibuffer C-x C-f binding. Your solution merely replaced ibuffer-find-file with counsel-find-file, leveraging the nice ivy-rich setup you had made, but discarding the idea behind ibuffer-find-file, namely that the default initial input should be the folder of the highlighted buffer.

I wrote a function that keeps the best of both worlds. It is a modification of the stock ibuffer-find-file function, that forwards to counsel-find-file instead of plain find-file. I have tested it and it seems to work. I though I would push back my changes upstream, in case you're interested.

Tell me if you have any questions or further requirements.

Aymeric Agon-Rambosson