### PR TITLE
format Go files on save

### DIFF
--- a/lisp/init-go.el
+++ b/lisp/init-go.el
@@ -53,6 +53,10 @@
               ([remap xref-find-definitions] . godef-jump)
               ("C-c R" . go-remove-unused-imports)
               ("<f1>" . godoc-at-point))
+  :init
+  (when (executable-find "goimports")
+    (setq gofmt-command "goimports"))
+
   :config
   (use-package go-dlv)
   (use-package go-fill-struct)
@@ -76,7 +80,10 @@
 
   (use-package go-gen-test
     :bind (:map go-mode-map
-                ("C-c C-t" . go-gen-test-dwim))))
+                ("C-c C-t" . go-gen-test-dwim)))
+
+  ;; call gofmt before saving
+  (add-hook 'before-save-hook 'gofmt-before-save))
 
 ;; Local Golang playground for short snippes
 (use-package go-playground

--- a/lisp/init-highlight.el
+++ b/lisp/init-highlight.el
@@ -144,7 +144,7 @@
          (dired-mode . diff-hl-dired-mode))
   :config
   ;; Highlight on-the-fly
-  (diff-hl-flydiff-mode 1)
+  (diff-hl-flydiff-mode -1)
 
   ;; Set fringe style
   (setq-default fringes-outside-margins t)


### PR DESCRIPTION
- Add hook to save go files on save.
- Use `goimports` for fmt if executable is available.