### PR TITLE
Fix custom-post.el not loading with variable void

### DIFF
--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -141,7 +141,8 @@
 
   (setq doom-modeline-major-mode-color-icon t
         doom-modeline-minor-modes nil
-        doom-modeline-mu4e nil)
+        doom-modeline-mu4e nil
+        doom-modeline-mode-map nil)
   :bind (:map doom-modeline-mode-map
          ("C-<f6>" . doom-modeline-hydra/body))
   :pretty-hydra


### PR DESCRIPTION
custom-post.el not loading for me after this line change
https://github.com/seagle0128/.emacs.d/commit/a42e7096e79c698a1f3449ecace643f5540c2890#comments

```
custom-initialize-reset: Symbol’s value as variable is void: doom-modeline-mode-map
```
Here is my proposed fix.