### PR TITLE
Add one option to customize the message shown in the footer of the dashboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ For Example:
 (setq centaur-chinese-calendar nil)            ; Use Chinese calendar or not: t or nil
 (setq centaur-prettify-symbols-alist nil)      ; Alist of symbol prettifications
 (setq centaur-benchmark-init t)                ; Enable initialization benchmark or not: t or nil
+(setq centaur-dashboard-footer-message "Foo")  ; Set the message shown in the footer section on dashboard
 ```
 
 The default package archives is `melpa`. You can change it in `custom.el`, or

--- a/custom-example.el
+++ b/custom-example.el
@@ -16,6 +16,7 @@
 ;; (setq centaur-chinese-calendar nil)            ; Use Chinese calendar or not: t or nil
 ;; (setq centaur-prettify-symbols-alist nil)      ; Alist of symbol prettifications
 ;; (setq centaur-benchmark-init t)                ; Enable initialization benchmark or not: t or nil
+;; (setq centaur-dashboard-footer-message "Foo")  ; Set the message shown in the footer section on dashboard
 
 ;; For Emacs devel
 ;; (setq package-user-dir (locate-user-emacs-file (format "elpa-%s" emacs-major-version)))

--- a/lisp/init-custom.el
+++ b/lisp/init-custom.el
@@ -63,6 +63,11 @@
   :group 'centaur
   :type 'boolean)
 
+(defcustom centaur-dashboard-footer-message (format "Powered by Vincent Zhang, %s" (format-time-string "%Y"))
+  "Set the footer message that you want to show on the dashboard by setting a function."
+  :group 'centaur
+  :type 'string)
+
 ;; ELPA: refer to https://github.com/melpa/melpa and https://elpa.emacs-china.org/.
 (defcustom centaur-package-archives-alist
   (let* ((no-ssl (and (memq system-type '(windows-nt ms-dos))

--- a/lisp/init-custom.el
+++ b/lisp/init-custom.el
@@ -64,7 +64,7 @@
   :type 'boolean)
 
 (defcustom centaur-dashboard-footer-message (format "Powered by Vincent Zhang, %s" (format-time-string "%Y"))
-  "Set the footer message that you want to show on the dashboard by setting a function."
+  "Set the footer message that you want to show on the dashboard."
   :group 'centaur
   :type 'string)
 

--- a/lisp/init-dashboard.el
+++ b/lisp/init-dashboard.el
@@ -101,7 +101,7 @@
                                     (registers . "database"))
 
           dashboard-set-footer t
-          dashboard-footer (format "Powered by Vincent Zhang, %s" (format-time-string "%Y"))
+          dashboard-footer centaur-dashboard-footer-message
           dashboard-footer-icon (cond ((display-graphic-p)
                                        (all-the-icons-faicon "heart"
                                                              :height 1.1


### PR DESCRIPTION
See the commits. I think it's better to have it easy to customize.
And I try to apply the same approach to the `dashboard-footer-icon`, but failed because the `init-custom` is loaded before `init-dashboard` in which we have `all-the-icons-faicon` cleared in use-package.  
I hope it can be solved either.

(Sorry for that I'm new to elisp in case I have made any low-level mistake.)