### PR TITLE
Add control over lsp-format-buffer

### DIFF
--- a/lisp/init-lsp.el
+++ b/lisp/init-lsp.el
@@ -54,13 +54,19 @@
 
                           ;; Format and organize imports
                           (unless (derived-mode-p 'c-mode 'c++-mode)
-                            (add-hook 'before-save-hook #'lsp-format-buffer t t)
+                            (unless lsp-no-autoformat-on-save
+                              (add-hook 'before-save-hook #'lsp-format-buffer t t))
                             (add-hook 'before-save-hook #'lsp-organize-imports t t)))))
      :bind (:map lsp-mode-map
             ("C-c C-d" . lsp-describe-thing-at-point)
             ([remap xref-find-definitions] . lsp-find-definition)
             ([remap xref-find-references] . lsp-find-references))
      :init
+     (defcustom lsp-no-autoformat-on-save nil
+       "No `lsp-format-buffer' automatically on save."
+       :group 'lsp
+       :type 'boolean)
+
      ;; @see https://github.com/emacs-lsp/lsp-mode#performance
      (setq read-process-output-max (* 1024 1024)) ;; 1MB
 


### PR DESCRIPTION

Hello Vincent,

I'm having some mixed feelings about this line since it's messing too many times with my code that I don't want automagically formatted on save (in my case Ruby):
https://github.com/seagle0128/.emacs.d/blob/0a8b1b5ffe1070a669722c8f44f088f8bd70f5a4/lisp/init-lsp.el#L58

I would suggest we add control over lsp-format-buffer with lsp-no-autoformat-on-save
 on custom-post.el or enable a way to control the list of languages we don't want that automation for, like 'c-mode 'c++-mode.

Once again thank you for your awesome work!
Ricardo Amaro