### PR TITLE
Org: add org-roam mode

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -255,6 +255,17 @@ prepended to the element after the #+HEADER: tag."
     :bind (:map org-agenda-mode-map
            ("P" . org-pomodoro))))
 
+;; org-roam
+(use-package org-roam
+  :hook
+  (after-init . org-roam-mode)
+  :bind (:map org-roam-mode-map
+         (("C-c n l" . org-roam)
+          ("C-c n f" . org-roam-find-file)
+          ("C-c n g" . org-roam-show-graph))
+         :map org-mode-map
+         (("C-c n i" . org-roam-insert))))
+
 (provide 'init-org)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
First we need to use the straight package manager from
https://github.com/raxod502/straight.el. This allows us to pull packages directly
from Github, which are not yet added to MELPA.

Next off we add the recommended config for org-roam from
https://github.com/jethrokuan/org-roam. Currently it's using straight and we can
move to completely using MELPA when the PR (https://github.com/jethrokuan/org-roam)
gets merged.

Signed-off-by: karthik nayak <karthik.188@gmail.com>