### PR TITLE
Inhibit markdown builtin style map prompt

### DIFF
--- a/lisp/init-markdown.el
+++ b/lisp/init-markdown.el
@@ -85,6 +85,7 @@ mermaid.initialize({
 
   ;; Use `which-key' instead
   (advice-add #'markdown--command-map-prompt :override #'ignore)
+  (advice-add #'markdown--style-map-prompt   :override #'ignore)
   :config
   (add-to-list 'markdown-code-lang-modes '("mermaid" . mermaid-mode))
 


### PR DESCRIPTION
Use `which-key` instead.