### PR TITLE
add shortcut for org-roam (org-roam-insert-immediate)

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -267,7 +267,8 @@ prepended to the element after the #+HEADER: tag."
             ("C-c n f" . org-roam-find-file)
             ("C-c n g" . org-roam-graph))
            :map org-mode-map
-           (("C-c n i" . org-roam-insert)))))
+           (("C-c n i" . org-roam-insert))
+           (("C-c n I" . org-roam-insert-immediate)))))
 
 (provide 'init-org)
 


### PR DESCRIPTION
[org-roam](https://github.com/seagle0128/.emacs.d) has already updated.

> ```emacs-lisp
> (use-package org-roam
>       :ensure t
>       :hook
>       (after-init . org-roam-mode)
>       :custom
>       (org-roam-directory "/path/to/org-files/")
>       :bind (:map org-roam-mode-map
>               (("C-c n l" . org-roam)
>                ("C-c n f" . org-roam-find-file)
>                ("C-c n g" . org-roam-graph-show))
>               :map org-mode-map
>               (("C-c n i" . org-roam-insert))
>               (("C-c n I" . org-roam-insert-immediate))))
> ```