### PR TITLE
Fixed: display inline image after execution

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -101,7 +101,7 @@ prepended to the element after the #+HEADER: tag."
                   (if (or (region-active-p) (looking-back "^\s*" 1))
                       (org-hydra/body)
                     (self-insert-command 1)))))
-  :hook (((org-babel-after-execution org-mode) . org-redisplay-inline-images) ; display image
+  :hook (((org-babel-after-execute org-mode) . org-redisplay-inline-images) ; display image
          (org-mode . (lambda ()
                        "Beautify org symbols."
                        (setq prettify-symbols-alist centaur-prettify-org-symbols-alist)


### PR DESCRIPTION
The `org-babel-after-execution-hook` doesn't exist.