### PR TITLE
Fix void symbol path

### DIFF
--- a/lisp/init-bookmark.el
+++ b/lisp/init-bookmark.el
@@ -51,7 +51,7 @@
                                 ((file-remote-p location)
                                  (all-the-icons-octicon "radio-tower" :height 0.8 :v-adjust 0.0))
                                 ((file-directory-p location)
-                                 (all-the-icons-icon-for-dir path :height 0.9 :v-adjust 0.01))
+                                 (all-the-icons-icon-for-dir location :height 0.9 :v-adjust 0.01))
                                 ((not (string-empty-p file))
                                  (all-the-icons-icon-for-file file :height 0.9 :v-adjust 0.0)))))
               (push (list


### PR DESCRIPTION
There is a new feature to show icons in *bookmark list*. But I noticed a typo may exist in the init-bookmark.el, at line 54. The symbol "path" is undefined and it causes nothing is shown in the *bookmark list* when excute command "my-bookmark-bmenu-list". I change the symbol "path" to "location" and bookmarks are shown with icon correctly. I guess it is a typo and simply modify it.