### PR TITLE
Change TAGS to tags as Citre doesn't support TAGS

### DIFF
--- a/lisp/init-custom.el
+++ b/lisp/init-custom.el
@@ -196,12 +196,12 @@ If Non-nil, save and restore the frame's geometry."
 
 `lsp-mode': See https://github.com/emacs-lsp/lsp-mode.
 `eglot': See https://github.com/joaotavora/eglot.
-tags: Use TAGS instead of language server. See https://github.com/universal-ctags/citre.
+tags: Use tags file instead of language server. See https://github.com/universal-ctags/citre.
 nil means disabled."
   :group 'centaur
   :type '(choice (const :tag "LSP Mode" lsp-mode)
                  (const :tag "Eglot" eglot)
-                 (const :tag "TAGS" tags)
+                 (const :tag "tags" tags)
                  (const :tag "Disable" nil)))
 
 (defcustom centaur-lsp-format-on-save-ignore-modes


### PR DESCRIPTION
TAGS file format is generated by `$ ctags -e` or `etags`. tags file format is the default format generated by `ctags`.

I don't know if these are formal names, but they are what we used for discussion in the Universal Ctags organization.

Citre doesn't support TAGS format, as readtags doesn't support it.