### PR TITLE
Fix Symbol's function definition is void: dashboard-center-line

### DIFF
--- a/lisp/init-dashboard.el
+++ b/lisp/init-dashboard.el
@@ -156,7 +156,7 @@
           (insert-image spec)
           (insert "\n\n")
           (when title
-            (dashboard-center-line title)
+            (dashboard-insert-center title)
             (insert (format "%s\n\n" (propertize title 'face 'dashboard-banner-logo-title)))))))
     (advice-add #'dashboard-insert-image-banner :override #'my-dashboard-insert-image-banner)
 
@@ -166,7 +166,7 @@
       "Insert copyright in the footer."
       (when dashboard-footer
         (insert "\n  ")
-        (dashboard-center-line dashboard-footer)
+        (dashboard-insert-center dashboard-footer)
         (insert (propertize dashboard-footer 'face 'font-lock-comment-face))
         (insert "\n")))
     (advice-add #'dashboard-insert-footer :after #'my-dashboard-insert-copyright)


### PR DESCRIPTION
It was removed and added dashboard-center-text instead at https://github.com/emacs-dashboard/emacs-dashboard/commit/48860b18b3b6ffac87b281c417ab11dd0578efc8