### PR TITLE
support disabling all lsp auto formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ For Example:
 (setq centaur-dashboard nil)                   ; Display dashboard at startup or not: t or nil
 (setq centaur-restore-frame-geometry nil)      ; Restore the frame's geometry at startup: t or nil
 (setq centaur-lsp 'eglot)                      ; Set LSP client: lsp-mode, eglot or nil
+(setq centaur-lsp-format-disable-on-save t)    ; disable the on save formatting for all files
 (setq centaur-lsp-format-on-save-ignore-modes '(c-mode c++-mode python-mode markdown-mode)) ; Ignore format on save for some languages
 (setq centaur-tree-sitter t)                   ; Enable `tree-sitter' or not: t or nil
 (setq centaur-chinese-calendar nil)            ; Support Chinese calendar or not: t or nil

--- a/custom-example.el
+++ b/custom-example.el
@@ -17,6 +17,7 @@
 ;; (setq centaur-dashboard nil)                   ; Display dashboard at startup or not: t or nil
 ;; (setq centaur-restore-frame-geometry nil)      ; Restore the frame's geometry at startup: t or nil
 ;; (setq centaur-lsp 'eglot)                      ; Set LSP client: lsp-mode, eglot or nil
+;; (setq centaur-lsp-format-disable-on-save t)    ; disable the on save formatting for all files
 ;; (setq centaur-lsp-format-on-save-ignore-modes '(c-mode c++-mode python-mode markdown-mode)) ; Ignore format on save for some languages
 ;; (setq centaur-tree-sitter t)                   ; Enable `tree-sitter' or not: t or nil
 ;; (setq centaur-chinese-calendar t)              ; Support Chinese calendar or not: t or nil

--- a/lisp/init-custom.el
+++ b/lisp/init-custom.el
@@ -209,6 +209,12 @@ nil means disabled."
   :group 'centaur
   :type 'boolean)
 
+(defcustom centaur-lsp-format-disable-on-save
+  nil
+  "Disable auto formatting for all files."
+  :group 'centaur
+  :type 'boolean)
+
 (defcustom centaur-lsp-format-on-save-ignore-modes
   '(c-mode c++-mode python-mode markdown-mode)
   "The modes that don't auto format and organize imports while saving the buffers.

--- a/lisp/init-lsp.el
+++ b/lisp/init-lsp.el
@@ -63,7 +63,7 @@
                           (lsp-enable-which-key-integration)
 
                           ;; Format and organize imports
-                          (unless (apply #'derived-mode-p centaur-lsp-format-on-save-ignore-modes)
+                          (unless (or (apply #'derived-mode-p centaur-lsp-format-on-save-ignore-modes) centaur-lsp-format-disable-on-save)
                             (add-hook 'before-save-hook #'lsp-format-buffer t t)
                             (add-hook 'before-save-hook #'lsp-organize-imports t t)))))
      :bind (:map lsp-mode-map


### PR DESCRIPTION
could not get disabling for a specific mode to work, this adds a flag that allows auto formatting to always be disabled, no matter the mode.

defaults to the current implementation (enabled)