### PR TITLE
add gfm to org-export-backends

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -178,7 +178,7 @@ prepended to the element after the #+HEADER: tag."
 
   ;; Add gfm/md backends
   (use-package ox-gfm)
-  (add-to-list 'org-export-backends 'md)
+  (add-to-list 'org-export-backends 'gfm)
 
   (with-eval-after-load 'counsel
     (bind-key [remap org-set-tags-command] #'counsel-org-tag org-mode-map))


### PR DESCRIPTION
'md 是 orgmode 原始的 markdown 导出器，ox-gfm 这个包应该是 'gfm