### PR TITLE
Fix missing icon error in LSP-UI hydra

### DIFF
--- a/lisp/init-lsp.el
+++ b/lisp/init-lsp.el
@@ -161,7 +161,7 @@
      :custom-face
      (lsp-ui-sideline-code-action ((t (:inherit warning))))
      :pretty-hydra
-     ((:title (pretty-hydra-title "LSP UI" 'faicon "nf-fa-rocket_launch" :face 'nerd-icons-green)
+     ((:title (pretty-hydra-title "LSP UI" 'faicon "nf-fa-rocket" :face 'nerd-icons-green)
        :color amaranth :quit-key ("q" "C-g"))
       ("Doc"
        (("d e" (progn


### PR DESCRIPTION
Fixes missing icon error in LSP-UI hydra
> nerd-icons-faicon: Unable to find icon with name ‘nf-fa-rocket_launch’ in icon set ‘faicon’`