### PR TITLE
Fix: keybinding conflict between Magit and ace-window

### DIFF
--- a/lisp/init-vcs.el
+++ b/lisp/init-vcs.el
@@ -40,7 +40,13 @@
   :config
   (when sys/win32p
     (setenv "GIT_ASKPASS" "git-gui--askpass"))
-
+             
+  ;; Unbind Magit's M-1, M-2, M-3, and M-4 shortcuts due to conflict with ace-window
+  (define-key magit-mode-map (kbd "M-1") nil)
+  (define-key magit-mode-map (kbd "M-2") nil)
+  (define-key magit-mode-map (kbd "M-3") nil)
+  (define-key magit-mode-map (kbd "M-4") nil)
+             
   ;; Access Git forges from Magit
   (use-package forge
     :demand t


### PR DESCRIPTION
Unbound M-1 to M-4 in Magit to prevent overlap with ace-window shortcuts.