### PR TITLE
fix auto-dark errors on mac-port

### DIFF
--- a/lisp/init-ui.el
+++ b/lisp/init-ui.el
@@ -73,14 +73,18 @@
                 (menu-bar-mode -1))))
 
   (defun refresh-ns-appearance ()
-    "Refresh frame parameter ns-appearance."
+    "Safely refresh frame parameter `ns-appearance' to match background mode."
+    (interactive)
     (let ((bg (frame-parameter nil 'background-mode)))
       (set-frame-parameter nil 'ns-appearance bg)
-      (setcdr (assq 'ns-appearance default-frame-alist) bg)))
+      (setf (alist-get 'ns-appearance default-frame-alist) bg)))
+
+  ;; Hook up appearance refresh to theme changes
   (add-hook 'after-load-theme-hook #'refresh-ns-appearance)
-  (with-eval-after-load'auto-dark
-   (add-hook 'auto-dark-dark-mode-hook #'refresh-ns-appearance)
-   (add-hook 'auto-dark-light-mode-hook #'refresh-ns-appearance)))
+
+  (with-eval-after-load 'auto-dark
+    (dolist (hook '(auto-dark-dark-mode-hook auto-dark-light-mode-hook))
+      (add-hook hook #'refresh-ns-appearance))))
 
 ;; Theme
 (if (centaur-compatible-theme-p centaur-theme)


### PR DESCRIPTION
Debugger entered--Lisp error: (wrong-type-argument consp nil)
  setcdr(nil light)
  (let ((bg (frame-parameter nil 'background-mode))) (set-frame-parameter nil 'ns-appearance bg) (setcdr (assq 'ns-appearance default-frame-alist) bg))
  refresh-ns-appearance()
  run-hooks(after-load-theme-hook)
  run-after-load-theme-hook(doom-oksolar-light t)
  apply(run-after-load-theme-hook (doom-oksolar-light t))
  #f(advice run-after-load-theme-hook :after #f(compiled-function (theme &optional no-confirm no-enable) "Load Custom theme named THEME from its file and possibly enable it.\nThe theme file is named THEME-theme.el, in one of the directories\nspecified by `custom-theme-load-path'.\n\nIf the theme is not considered safe by `custom-safe-themes',\nprompt the user for confirmation before loading it.  But if\noptional arg NO-CONFIRM is non-nil, load the theme without\nprompting.\n\nNormally, this function also enables THEME.  If optional arg\nNO-ENABLE is non-nil, load the theme but don't enable it, unless\nthe theme was already enabled.\n\nNote that enabling THEME does not disable any other\nalready-enabled themes.  If THEME is enabled, it has the highest\nprecedence (after `user') among enabled themes.  To disable other\nthemes, use `disable-theme'.\n\nThis function is normally called through Customize when setting\n`custom-enabled-themes'.  If used directly in your init file, it\nshould be called with a non-nil NO-CONFIRM argument, or after\n`custom-safe-themes' has been loaded.\n\nReturn t if THEME was successfully loaded, nil otherwise." (interactive #f(compiled-function () #<bytecode -0x1418da4d29b99574>)) #<bytecode 0xc990e64b6a91c1f>))(doom-oksolar-light t)
  apply(#f(advice run-after-load-theme-hook :after #f(compiled-function (theme &optional no-confirm no-enable) "Load Custom theme named THEME from its file and possibly enable it.\nThe theme file is named THEME-theme.el, in one of the directories\nspecified by `custom-theme-load-path'.\n\nIf the theme is not considered safe by `custom-safe-themes',\nprompt the user for confirmation before loading it.  But if\noptional arg NO-CONFIRM is non-nil, load the theme without\nprompting.\n\nNormally, this function also enables THEME.  If optional arg\nNO-ENABLE is non-nil, load the theme but don't enable it, unless\nthe theme was already enabled.\n\nNote that enabling THEME does not disable any other\nalready-enabled themes.  If THEME is enabled, it has the highest\nprecedence (after `user') among enabled themes.  To disable other\nthemes, use `disable-theme'.\n\nThis function is normally called through Customize when setting\n`custom-enabled-themes'.  If used directly in your init file, it\nshould be called with a non-nil NO-CONFIRM argument, or after\n`custom-safe-themes' has been loaded.\n\nReturn t if THEME was successfully loaded, nil otherwise." (interactive #f(compiled-function () #<bytecode -0x1418da4d29b99574>)) #<bytecode 0xc990e64b6a91c1f>)) (doom-oksolar-light t))
  load-theme(doom-oksolar-light t)
  (progn (mapc #'disable-theme custom-enabled-themes) (load-theme theme t))
  (if theme (progn (mapc #'disable-theme custom-enabled-themes) (load-theme theme t)))
  (let* ((theme (and t (centaur--theme-name theme)))) (if theme (progn (mapc #'disable-theme custom-enabled-themes) (load-theme theme t))))
  centaur--load-theme(doom-oksolar-light)
  (let nil (centaur--load-theme theme))
  (cond ((eq theme 'auto) (let nil (progn (use-package-ensure-elpa 'circadian '(t) 'nil) (defvar use-package--warning0 #'(lambda (keyword err) (let ... ...))) (condition-case err (progn (let (...) (if ... nil ... ... ...) (custom-theme-set-variables ... ...)) (if (fboundp ...) nil (autoload ... "circadian" nil t)) (if (fboundp ...) nil (autoload ... "circadian" nil t)) (condition-case err (circadian-setup) (... ...))) ((debug error) (funcall use-package--warning0 :catch err)))))) ((eq theme 'system) (let nil (progn (use-package-ensure-elpa 'auto-dark '(t) 'nil) (defvar use-package--warning1 #'(lambda (keyword err) (let ... ...))) (condition-case err (progn (if (fboundp ...) nil (autoload ... "auto-dark" nil t)) (condition-case err (progn ... ... ...) (... ...)) (eval-after-load 'auto-dark #'...)) ((debug error) (funcall use-package--warning1 :catch err)))))) ((eq theme 'random) (let nil (centaur-load-random-theme))) (t (let nil (centaur--load-theme theme))))
  centaur-load-theme(doom-oksolar-light)
  #f(lambda () [t] (interactive nil) (centaur-load-theme (intern (completing-read "Load custom theme: " (mapcar #'symbol-name (custom-available-themes))))))()
  funcall-interactively(#f(lambda () [t] (interactive nil) (centaur-load-theme (intern (completing-read "Load custom theme: " (mapcar #'symbol-name (custom-available-themes)))))))
  call-interactively(#f(lambda () [t] (interactive nil) (centaur-load-theme (intern (completing-read "Load custom theme: " (mapcar #'symbol-name (custom-available-themes)))))))
  (if remapped-cmd (call-interactively remapped-cmd) (call-interactively cmd))
  (let ((remapped-cmd (if hydra-look-for-remap (command-remapping cmd) nil))) (if remapped-cmd (call-interactively remapped-cmd) (call-interactively cmd)))
  hydra--call-interactively-remap-maybe(#f(lambda () [t] (interactive nil) (centaur-load-theme (intern (completing-read "Load custom theme: " (mapcar #'symbol-name (custom-available-themes)))))))
  toggles-hydra/lambda-t\ o-and-exit()
  funcall-interactively(toggles-hydra/lambda-t\ o-and-exit)
  call-interactively(toggles-hydra/lambda-t\ o-and-exit nil nil)
  command-execute(toggles-hydra/lambda-t\ o-and-exit)