### PR TITLE
Update init-dired.el to fix nerd-icons

### DIFF
--- a/lisp/init-dired.el
+++ b/lisp/init-dired.el
@@ -86,13 +86,16 @@
     :diminish
     :functions (nerd-icons-icon-for-dir my/nerd-icons-icon-for-dir)
     :hook dired-mode
-    :init
+    :init           
     (defface nerd-icons-dired-dir-face
       '((t (:inherit 'font-lock-doc-face)))
       "Face for the directory icon."
       :group 'nerd-icons-faces)
-    (defun my/nerd-icons-icon-for-dir (dir)
-      (nerd-icons-icon-for-dir dir :face 'nerd-icons-dired-dir-face))
+    (defun my/nerd-icons-icon-for-dir (dir &rest args)
+      (apply #'nerd-icons-icon-for-dir
+             dir
+             :face 'nerd-icons-dired-dir-face
+             args))               
     (setq nerd-icons-dired-dir-icon-function #'my/nerd-icons-icon-for-dir))
 
   ;; Extra Dired functionality


### PR DESCRIPTION
 `nerd-icons-dired` was updated to pass keyword args like `:height`, but compatibility wrapper in [init-dired.el](.emacs.d/lisp/init-dired.el:94) was not updated with `&rest args`.