### PR TITLE
Only enable org-modern if using GUI Emacs

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -214,6 +214,7 @@ prepended to the element after the #+HEADER: tag."
   (use-package org-modern
     :after org
     :diminish
+    :if (display-graphic-p)
     :autoload global-org-modern-mode
     :init (global-org-modern-mode 1)))
 


### PR DESCRIPTION
`org-modern` mode doesn't work great in terminal emacs, so it should be disabled if not in GUI Emacs according to the author: https://github.com/minad/org-modern/issues/116#issuecomment-1463995664